### PR TITLE
mulscc: fix swapped arguments

### DIFF
--- a/src/inst.c
+++ b/src/inst.c
@@ -596,8 +596,8 @@ void MULSCC (pDecode_t d)
     cc = (d->PSR >> PSR_CC_CARRY) & LOBITS4;
 
 
-    x = d->ev;
-    y = (Y & 1) ? (d->rs1_value >> 1) | ((((cc >> CC_OVERFLOW) ^ (cc >> CC_NEGATIVE)) &1) << 31) : 0;
+    x = (d->rs1_value >> 1) | ((((cc >> CC_OVERFLOW) ^ (cc >> CC_NEGATIVE)) &1) << 31);
+    y = (Y & 1) ? d->ev : 0;
 
     z = x + y;
 

--- a/test/mulscc.s
+++ b/test/mulscc.s
@@ -99,11 +99,25 @@ main:
         bne     .LFAIL
         nop
 
+        MOVW    (0x00002004, %l1)
+        MOVW    (0x00012345, %l2)
+        MOVW    (0x246d2d14, %l3)
+        MOVW    (0x0000fffe, %l4)
+        MOVW    (0x00001002, %g1)
+        SetCC   (0xa, %l5, %l6, %l7)
+        wr      %l4, %y
+
+        mulscc  %l1, %l2, %l5
+
+        cmp     %g1, %l5
+        bne     .LFAIL
+        nop
+
         MOVW    (0x00012345, %l1)
         MOVW    (0x00002004, %l2)
         MOVW    (0x246d2d14, %l3)
         MOVW    (0x0000fffe, %l4)
-        MOVW    (0x00002004, %g1)
+        MOVW    (0x000091a2, %g1)
         SetCC   (0xa, %l5, %l6, %l7)
         wr      %l4, %y
 


### PR DESCRIPTION
The specification [1] documents that:

  op1 = (n XOR v) CONCAT r[rs1]<31:1>
  if (Y<0> = 0) op2 = 0, else op2 = r[rs2] or sign extnd(simm13)

Note Y<0> deciding whether the second addition term is the second argument (RS2 or imm) or zero, the first one being RS1 with a sign bit. Not the other way around.

[1] SPARC 7 Instruction Set
    Rev. 4168C–AERO–08/01, Atmel Corporation, 2002
    MULScc, page 82
    <https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/UserGuides/doc4168.pdf>